### PR TITLE
Add a new test from deprecation and fix the properties for the versions in the BOM.

### DIFF
--- a/bom/bom/pom.xml
+++ b/bom/bom/pom.xml
@@ -25,22 +25,22 @@
             <dependency>
                 <groupId>dev.resteasy.netty</groupId>
                 <artifactId>resteasy-netty-embedded-server</artifactId>
-                <version>${project.version</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.netty</groupId>
                 <artifactId>resteasy-netty-embedded-server-cdi</artifactId>
-                <version>${project.version</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.netty</groupId>
                 <artifactId>resteasy-embedded-server-reactor</artifactId>
-                <version>${project.version</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.resteasy.netty</groupId>
                 <artifactId>resteasy-reactor-netty-client</artifactId>
-                <version>${project.version</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/embedded-server-reactor/pom.xml
+++ b/embedded-server-reactor/pom.xml
@@ -114,6 +114,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>dev.resteasy.netty</groupId>
+            <artifactId>resteasy-reactor-netty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/Async.java
+++ b/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/Async.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Async {
+
+}

--- a/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorInjector.java
+++ b/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorInjector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+import reactor.core.publisher.Mono;
+
+@Provider
+public class ReactorInjector implements ContextInjector<Mono<Integer>, Integer> {
+
+    @Override
+    public Mono<Integer> resolve(Class<? extends Mono<Integer>> rawType, Type genericType,
+            Annotation[] annotations) {
+        boolean async = false;
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType() == Async.class)
+                async = true;
+        }
+        if (!async)
+            return Mono.just(24);
+        return Mono.create(emitter -> {
+            new Thread(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    emitter.error(e);
+                    return;
+                }
+                emitter.success(42);
+            }).start();
+        });
+    }
+
+}

--- a/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorResource.java
+++ b/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.Stream;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Path("/")
+public class ReactorResource {
+    static final AtomicInteger monoEndpointCounter = new AtomicInteger(0);
+
+    @Path("mono")
+    @GET
+    public Mono<String> mono() {
+        monoEndpointCounter.incrementAndGet();
+        return Mono.just("got it");
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("flux")
+    @GET
+    @Stream
+    public Flux<String> flux() {
+        return Flux.just("one", "two");
+    }
+
+    @Path("injection")
+    @GET
+    public Mono<Integer> injection(@Context Integer value) {
+        return Mono.just(value);
+    }
+
+    @Path("injection-async")
+    @GET
+    public Mono<Integer> injectionAsync(@Async @Context Integer value) {
+        return Mono.just(value);
+    }
+
+    @Path("delay/{secs}")
+    @GET
+    public Mono<String> delay(@PathParam("secs") int delay) {
+        return Mono.just("I delayed for " + delay + " seconds.")
+                .delayElement(Duration.ofSeconds(delay));
+    }
+}

--- a/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorTest.java
+++ b/embedded-server-reactor/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.InvocationCallback;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ReactiveClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.reactor.MonoRxInvoker;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.netty.reactor.engine.ReactorNettyClientHttpEngine;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.DefaultEventExecutor;
+import reactor.core.publisher.Mono;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.util.context.Context;
+
+public class ReactorTest {
+    private static ReactorNettyJaxrsServer server;
+
+    private static CountDownLatch latch;
+    private static AtomicReference<Object> value = new AtomicReference<Object>();
+    private static final Logger LOG = Logger.getLogger(ReactorTest.class);
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        server = new ReactorNettyJaxrsServer();
+        server.setPort(TestPortProvider.getPort());
+        server.setRootResourcePath("/");
+        server.getDeployment().getActualResourceClasses().add(ReactorResource.class);
+        server.getDeployment().getActualProviderClasses().add(ReactorInjector.class);
+        server.getDeployment().start();
+        server.getDeployment().registration();
+        server.start();
+    }
+
+    @AfterAll
+    public static void afterClass() throws Exception {
+        server.stop();
+        server = null;
+    }
+
+    private ResteasyClient client;
+
+    @BeforeEach
+    public void before() {
+        final ReactorNettyClientHttpEngine reactorEngine = new ReactorNettyClientHttpEngine(
+                HttpClient.create(),
+                new DefaultChannelGroup(new DefaultEventExecutor()),
+                ConnectionProvider.newConnection());
+        client = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+                .httpEngine(reactorEngine)
+                .readTimeout(5, TimeUnit.SECONDS)
+                .connectionCheckoutTimeout(5, TimeUnit.SECONDS)
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .build();
+        value.set(null);
+        latch = new CountDownLatch(1);
+    }
+
+    @AfterEach
+    public void after() {
+        client.close();
+    }
+
+    @Test
+    public void testSubscriberContext() {
+        final String ctxKey = "secret";
+        final List<Integer> secrets = new ArrayList<>();
+
+        // With the `Publisher` bridge, the end user's subscriber context is available when the
+        // reactor-netty client is instantiated.  This can be useful for things like trace logging.
+        final HttpClient reactorClient = HttpClient.create()
+                .doOnRequest((req, conn) -> req.currentContextView().<Integer> getOrEmpty(ctxKey).ifPresent(secrets::add));
+
+        final ReactorNettyClientHttpEngine reactorEngine = new ReactorNettyClientHttpEngine(
+                reactorClient,
+                new DefaultChannelGroup(new DefaultEventExecutor()),
+                ConnectionProvider.newConnection());
+
+        final ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+                .httpEngine(reactorEngine)
+                .readTimeout(5, TimeUnit.SECONDS)
+                .connectionCheckoutTimeout(5, TimeUnit.SECONDS)
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .build();
+
+        final Supplier<Mono<String>> getFn = () -> client.target(generateURL("/mono")).request().rx(MonoRxInvoker.class)
+                .get(String.class);
+
+        Mono<String> mono = getFn.get()
+                .flatMap(
+                        resp1 -> getFn.get()
+                                .flatMap(resp2 -> getFn.get().map(resp3 -> String.join("-", Arrays.asList(resp1, resp2, resp3)))
+                                        .contextWrite(Context.of(ctxKey, 24))))
+                .contextWrite(ctx -> ctx.put(ctxKey, 42));
+
+        Assertions.assertEquals("got it-got it-got it", mono.block());
+        Assertions.assertTrue(equalTo(secrets, Arrays.asList(42, 42, 24)));
+    }
+
+    @Test
+    public void testTimeoutOverridePerRequest() throws Exception {
+        // This also tests that the client will eagerly close the connection
+        // in the case of a business logic timeout.
+        final Duration serverResponseDelay = Duration.ofSeconds(60);
+        final CountDownLatch serverConnDisconnectingEvent = new CountDownLatch(1);
+        final DisposableServer server = HttpServer.create()
+                .childObserve((conn, state) -> {
+                    if (state == ConnectionObserver.State.DISCONNECTING) {
+                        serverConnDisconnectingEvent.countDown();
+                    }
+                })
+                .handle((req, resp) -> resp.sendString(Mono.just("I'm delayed!").delayElement(serverResponseDelay)))
+                .bindNow();
+
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            final HttpClient reactorClient = HttpClient.create();
+
+            final ReactorNettyClientHttpEngine reactorEngine = new ReactorNettyClientHttpEngine(
+                    reactorClient,
+                    new DefaultChannelGroup(new DefaultEventExecutor()),
+                    ConnectionProvider.builder("clientconns").maxConnections(1).build());
+
+            final AtomicReference<Exception> innerTimeoutException = new AtomicReference<>();
+
+            final ReactiveClientHttpEngine wrappedEngine = new ReactiveClientHttpEngine() {
+                private <T> Mono<T> recordTimeout(final Mono<T> m) {
+                    return m.doOnError(TimeoutException.class, innerTimeoutException::set);
+                }
+
+                public <T> Mono<T> submitRx(ClientInvocation request, boolean buffered, ResultExtractor<T> extractor) {
+                    return recordTimeout(reactorEngine.submitRx(request, buffered, extractor));
+                }
+
+                public <T> Mono<T> fromCompletionStage(CompletionStage<T> cs) {
+                    return recordTimeout(reactorEngine.fromCompletionStage(cs));
+                }
+
+                public <T> Mono<T> just(T t) {
+                    return recordTimeout(reactorEngine.just(t));
+                }
+
+                public Mono error(Exception e) {
+                    return recordTimeout(reactorEngine.error(e));
+                }
+
+                public <T> Future<T> submit(ClientInvocation request, boolean buffered, InvocationCallback<T> callback,
+                        ResultExtractor<T> extractor) {
+                    return reactorEngine.submit(request, buffered, callback, extractor);
+                }
+
+                public <K> CompletableFuture<K> submit(ClientInvocation request, boolean buffered, ResultExtractor<K> extractor,
+                        ExecutorService executorService) {
+                    return reactorEngine.submit(request, buffered, extractor, executorService);
+                }
+
+                public SSLContext getSslContext() {
+                    return reactorEngine.getSslContext();
+                }
+
+                public HostnameVerifier getHostnameVerifier() {
+                    return reactorEngine.getHostnameVerifier();
+                }
+
+                public Response invoke(Invocation request) {
+                    return reactorEngine.invoke(request);
+                }
+
+                public void close() {
+                    reactorEngine.close();
+                }
+            };
+
+            final Duration innerTimeout = Duration.ofSeconds(5);
+            final ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+                    .httpEngine(wrappedEngine)
+                    .readTimeout(innerTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                    .build();
+
+            client.target("http://localhost:" + server.port() + "/")
+                    .request()
+                    .rx(MonoRxInvoker.class)
+                    .get(String.class)
+                    .timeout(Duration.ofMillis(500))
+                    .subscribe(
+                            ignore -> {
+                                Assertions.fail("Should have got timeout exception");
+                            },
+                            t -> {
+                                if (!(t instanceof TimeoutException)) {
+                                    Assertions.assertTrue(t.getMessage().contains("signal within 500ms")); // crappy assertion:(
+                                }
+                                latch.countDown();
+                            },
+                            latch::countDown);
+
+            Assertions.assertNull(innerTimeoutException.get(), "Inner timeout should not have occurred!");
+            Assertions.assertTrue(latch.await(innerTimeout.multipliedBy(2).toMillis(), TimeUnit.MILLISECONDS),
+                    "Test timed out");
+            Assertions.assertTrue(serverConnDisconnectingEvent.await(
+                    serverResponseDelay.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS), "Server disconnect didn't happen.");
+        } finally {
+            server.disposeNow();
+        }
+    }
+
+    // the order of the values in the 2 lists must be the same
+    private boolean equalTo(List<Integer> src, List<Integer> control) {
+        if (src.size() == control.size()) {
+            for (int i = 0; i < src.size(); i++) {
+                if (src.get(i).intValue() != control.get(i).intValue()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
The `ReactorTest` was migrated to the reactor embedded server in https://github.com/resteasy/resteasy/pull/4682. Add it here so that we don't lose test coverage.