### PR TITLE
Wait for pending body writes before completing Netty responses

### DIFF
--- a/embedded-server/pom.xml
+++ b/embedded-server/pom.xml
@@ -115,6 +115,11 @@
             <artifactId>resteasy-jaxb-provider</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- This needs a new release of RESTEasy 6.2.13+ for this to be included
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/netty/ChunkOutputStream.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/netty/ChunkOutputStream.java
@@ -6,6 +6,7 @@
 package org.jboss.resteasy.plugins.server.netty;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -14,9 +15,11 @@ import org.jboss.resteasy.spi.AsyncOutputStream;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.util.concurrent.Future;
 
 /**
  * Class to help application that are built to write to an
@@ -43,6 +46,12 @@ public class ChunkOutputStream extends AsyncOutputStream {
     private final ByteBuf buffer;
     private final ChannelHandlerContext ctx;
     private final NettyHttpResponse response;
+    // All lifecycle state below is guarded by writeLock.
+    private int pendingWrites = 0;
+    private Throwable writeFailure = null;
+    private ChannelPromise responsePromise = null;
+    private boolean finishRequested = false;
+    private boolean responseWriteStarted = false;
 
     ChunkOutputStream(final NettyHttpResponse response, final ChannelHandlerContext ctx, final int chunksize) {
         this.response = response;
@@ -56,6 +65,7 @@ public class ChunkOutputStream extends AsyncOutputStream {
     @Override
     public void write(int b) throws IOException {
         synchronized (writeLock) {
+            ensureOpen();
             if (buffer.maxWritableBytes() < 1) {
                 flush();
             }
@@ -67,6 +77,8 @@ public class ChunkOutputStream extends AsyncOutputStream {
         if (response.isCommitted())
             throw new IllegalStateException(Messages.MESSAGES.responseIsCommitted());
         synchronized (writeLock) {
+            if (finishRequested)
+                throw new IllegalStateException(Messages.MESSAGES.responseIsCommitted());
             buffer.clear();
         }
     }
@@ -88,6 +100,7 @@ public class ChunkOutputStream extends AsyncOutputStream {
         int spaceLeftInCurrentChunk;
         MultiPromise mp = new MultiPromise(ctx, promise);
         synchronized (writeLock) {
+            ensureOpen();
             while ((spaceLeftInCurrentChunk = buffer.maxWritableBytes()) < dataLengthLeftToWrite) {
                 buffer.writeBytes(b, dataToWriteOffset, spaceLeftInCurrentChunk);
                 dataToWriteOffset = dataToWriteOffset + spaceLeftInCurrentChunk;
@@ -109,6 +122,7 @@ public class ChunkOutputStream extends AsyncOutputStream {
 
     private void flush(ChannelPromise promise) throws IOException {
         synchronized (writeLock) {
+            ensureOpen();
             int readable = buffer.readableBytes();
             if (readable == 0) {
                 promise.setSuccess();
@@ -116,6 +130,8 @@ public class ChunkOutputStream extends AsyncOutputStream {
             }
             if (!response.isCommitted())
                 response.prepareChunkStream();
+            pendingWrites++;
+            promise.addListener(this::bodyWriteComplete);
             ctx.writeAndFlush(new DefaultHttpContent(buffer.copy()), promise);
             buffer.clear();
         }
@@ -156,5 +172,86 @@ public class ChunkOutputStream extends AsyncOutputStream {
             ret.completeExceptionally(e);
         }
         return ret;
+    }
+
+    /**
+     * Closes the entity-output lifecycle and completes the HTTP response after every body write has completed.
+     * The entity stream can wrap this root stream, hence it is flushed while holding the write lock. Any tail emitted by
+     * that flush is registered before the response is marked as finished.
+     */
+    ChannelFuture finish(OutputStream entityOutputStream) throws IOException {
+        ChannelPromise result;
+        boolean completeResponse;
+        synchronized (writeLock) {
+            if (finishRequested) {
+                return responsePromise;
+            }
+            if (entityOutputStream != null) {
+                entityOutputStream.flush();
+            }
+            finishRequested = true;
+            responsePromise = ctx.newPromise();
+            result = responsePromise;
+            completeResponse = pendingWrites == 0;
+        }
+        if (completeResponse) {
+            completeResponse();
+        }
+        return result;
+    }
+
+    private void ensureOpen() throws IOException {
+        if (finishRequested) {
+            throw new IOException(Messages.MESSAGES.responseIsCommitted());
+        }
+    }
+
+    private void bodyWriteComplete(Future<?> future) {
+        boolean completeResponse;
+        synchronized (writeLock) {
+            pendingWrites--;
+            if (!future.isSuccess() && writeFailure == null) {
+                writeFailure = future.cause() == null
+                        ? new IOException("Response body write failed without a cause")
+                        : future.cause();
+            }
+            completeResponse = finishRequested && pendingWrites == 0;
+        }
+        if (!future.isSuccess()) {
+            // Once body bytes may have reached the peer, only closing the transport can prevent a clean partial response.
+            ctx.close();
+        }
+        if (completeResponse) {
+            completeResponse();
+        }
+    }
+
+    private void completeResponse() {
+        final ChannelPromise result;
+        final Throwable failure;
+        synchronized (writeLock) {
+            if (!finishRequested || pendingWrites != 0 || responseWriteStarted) {
+                return;
+            }
+            responseWriteStarted = true;
+            result = responsePromise;
+            failure = writeFailure;
+        }
+
+        if (failure != null) {
+            ctx.close().addListener(ignored -> result.tryFailure(failure));
+            return;
+        }
+
+        response.writeResponseTermination().addListener(future -> {
+            if (future.isSuccess()) {
+                result.trySuccess();
+            } else {
+                Throwable cause = future.cause() == null
+                        ? new IOException("Response termination write failed without a cause")
+                        : future.cause();
+                ctx.close().addListener(ignored -> result.tryFailure(cause));
+            }
+        });
     }
 }

--- a/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
+++ b/embedded-server/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
@@ -32,19 +32,28 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 
 /**
+ * Body write submission and completion are ordered by the root {@link ChunkOutputStream}'s write lock. Terminal writes
+ * can be requested by RESTEasy dispatch or by an asynchronous Netty promise callback. {@link #sendError(int, String)}
+ * and {@link #writeResponseTermination()} therefore synchronize on this response, making terminal message selection,
+ * write submission and future publication one transition.
+ *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public class NettyHttpResponse implements HttpResponse {
     private static final int EMPTY_CONTENT_LENGTH = 0;
     private int status = 200;
-    private OutputStream os;
+    // RESTEasy writer interceptors can replace this stream with a wrapper around the root stream.
+    private OutputStream entityOutputStream;
+    // The root stream owns the Netty body-write promises and therefore remains stable when the entity stream is replaced.
+    private final ChunkOutputStream rootChunkOutputStream;
     private final MultivaluedMap<String, Object> outputHeaders;
     private final ChannelHandlerContext ctx;
     private boolean committed;
     private final boolean keepAlive;
     private final ResteasyProviderFactory providerFactory;
     private final HttpMethod method;
+    private ChannelFuture terminationFuture;
 
     public NettyHttpResponse(final ChannelHandlerContext ctx, final boolean keepAlive,
             final ResteasyProviderFactory providerFactory) {
@@ -55,15 +64,18 @@ public class NettyHttpResponse implements HttpResponse {
             final ResteasyProviderFactory providerFactory, final HttpMethod method) {
         outputHeaders = new MultivaluedMapImpl<String, Object>();
         this.method = method;
-        os = (method == null || !method.equals(HttpMethod.HEAD)) ? new ChunkOutputStream(this, ctx, 1000) : null; //[RESTEASY-1627]
+        rootChunkOutputStream = (method == null || !method.equals(HttpMethod.HEAD))
+                ? new ChunkOutputStream(this, ctx, 1000)
+                : null; //[RESTEASY-1627]
+        entityOutputStream = rootChunkOutputStream;
         this.ctx = ctx;
         this.keepAlive = keepAlive;
         this.providerFactory = providerFactory;
     }
 
     @Override
-    public void setOutputStream(OutputStream os) {
-        this.os = os;
+    public void setOutputStream(OutputStream entityOutputStream) {
+        this.entityOutputStream = entityOutputStream;
     }
 
     @Override
@@ -83,7 +95,7 @@ public class NettyHttpResponse implements HttpResponse {
 
     @Override
     public OutputStream getOutputStream() throws IOException {
-        return os;
+        return entityOutputStream;
     }
 
     @Override
@@ -97,7 +109,7 @@ public class NettyHttpResponse implements HttpResponse {
     }
 
     @Override
-    public void sendError(int status, String message) throws IOException {
+    public synchronized void sendError(int status, String message) throws IOException {
         if (committed) {
             throw new IllegalStateException();
         }
@@ -116,8 +128,8 @@ public class NettyHttpResponse implements HttpResponse {
         }
         // Add keep alive or connection close header
         transformResponseHeaders(response);
-        ctx.writeAndFlush(response);
         committed = true;
+        terminationFuture = ctx.writeAndFlush(response);
     }
 
     @Override
@@ -157,6 +169,10 @@ public class NettyHttpResponse implements HttpResponse {
         RestEasyHttpResponseEncoder.transformHeaders(this, res, providerFactory);
     }
 
+    /**
+     * Called by {@link ChunkOutputStream} while it holds its write lock. Body-write completion reacquires that lock before
+     * it can request termination, which makes this committed state visible to the completion path.
+     */
     public void prepareChunkStream() {
         committed = true;
         DefaultHttpResponse response = getDefaultHttpResponse();
@@ -165,14 +181,11 @@ public class NettyHttpResponse implements HttpResponse {
     }
 
     public void finish() throws IOException {
-        if (os != null)
-            os.flush();
         ChannelFuture future;
-        if (isCommitted()) {
-            // if committed this means the output stream was used.
-            future = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+        if (rootChunkOutputStream != null) {
+            future = rootChunkOutputStream.finish(entityOutputStream);
         } else {
-            future = ctx.writeAndFlush(getEmptyHttpResponse());
+            future = writeResponseTermination();
         }
 
         if (!isKeepAlive()) {
@@ -181,10 +194,20 @@ public class NettyHttpResponse implements HttpResponse {
 
     }
 
+    synchronized ChannelFuture writeResponseTermination() {
+        if (terminationFuture != null) {
+            return terminationFuture;
+        }
+        Object terminalMessage = isCommitted() ? LastHttpContent.EMPTY_LAST_CONTENT : getEmptyHttpResponse();
+        committed = true;
+        terminationFuture = ctx.writeAndFlush(terminalMessage);
+        return terminationFuture;
+    }
+
     @Override
     public void flushBuffer() throws IOException {
-        if (os != null)
-            os.flush();
+        if (entityOutputStream != null)
+            entityOutputStream.flush();
         ctx.flush();
     }
 }

--- a/embedded-server/src/test/java/org/jboss/resteasy/plugins/server/netty/ChunkOutputStreamProductionTruncationTest.java
+++ b/embedded-server/src/test/java/org/jboss/resteasy/plugins/server/netty/ChunkOutputStreamProductionTruncationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.netty;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.LastHttpContent;
+
+class ChunkOutputStreamProductionTruncationTest {
+
+    private static final int CHUNK_SIZE = 1_000;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void keepsTerminationBehindPlainJacksonTailWithMidStringPrefix() throws Exception {
+        ObjectNode json = MAPPER.createObjectNode().put("value", "x".repeat(1_500));
+
+        assertTerminationWaitsForTail(json, 512, (byte) 'x');
+    }
+
+    @Test
+    void keepsTerminationBehindPlainJacksonTailWithObjectEntryPrefix() throws Exception {
+        ObjectNode json = MAPPER.createObjectNode()
+                .put("padding", "x".repeat(986))
+                .put("value", "ok");
+
+        assertTerminationWaitsForTail(json, 13, (byte) ',');
+    }
+
+    @Test
+    void flushesReplacementEntityStreamBeforeWaitingForRootWrites() throws Exception {
+        ObjectNode json = MAPPER.createObjectNode().put("value", "x".repeat(1_500));
+
+        assertTerminationWaitsForTail(json, 512, (byte) 'x', true);
+    }
+
+    private static void assertTerminationWaitsForTail(ObjectNode json, int tailSize, byte finalPrefixByte)
+            throws Exception {
+        assertTerminationWaitsForTail(json, tailSize, finalPrefixByte, false);
+    }
+
+    private static void assertTerminationWaitsForTail(ObjectNode json, int tailSize, byte finalPrefixByte,
+            boolean replaceEntityStream) throws Exception {
+        byte[] body = MAPPER.writeValueAsBytes(json);
+        Assertions.assertEquals(CHUNK_SIZE + tailSize, body.length);
+        Assertions.assertEquals(finalPrefixByte, body[CHUNK_SIZE - 1]);
+
+        OutboundSequenceRecorder recorder = new OutboundSequenceRecorder();
+        DelayedTailHandler delayedTail = new DelayedTailHandler();
+        ContextCapture capture = new ContextCapture();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder(), recorder, delayedTail, capture);
+
+        try {
+            NettyHttpResponse response = new NettyHttpResponse(
+                    capture.context, true, ResteasyProviderFactory.getInstance());
+            OutputStream output = response.getOutputStream();
+            if (replaceEntityStream) {
+                output = new BufferedOutputStream(output, body.length + 1);
+                response.setOutputStream(output);
+            }
+            output.write(body);
+            response.finish();
+            channel.runPendingTasks();
+
+            List<String> messagesWhileTailPending = List.copyOf(recorder.messages);
+            List<Integer> bodySizesWhileTailPending = List.copyOf(recorder.bodySizes);
+
+            delayedTail.release();
+            channel.runPendingTasks();
+
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(List.of("HttpResponse", "HttpContent"), messagesWhileTailPending,
+                            "The response must remain unterminated while the Jackson tail is pending"),
+                    () -> Assertions.assertEquals(List.of(CHUNK_SIZE), bodySizesWhileTailPending),
+                    () -> Assertions.assertEquals(
+                            List.of("HttpResponse", "HttpContent", "HttpContent", "LastHttpContent"), recorder.messages),
+                    () -> Assertions.assertEquals(List.of(CHUNK_SIZE, tailSize), recorder.bodySizes),
+                    () -> Assertions.assertNull(delayedTail.failure.get(),
+                            "A body chunk reached the HTTP encoder after response termination"));
+        } finally {
+            delayedTail.release();
+            channel.runPendingTasks();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static final class ContextCapture extends ChannelInboundHandlerAdapter {
+
+        private ChannelHandlerContext context;
+
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) {
+            context = ctx;
+        }
+    }
+
+    private static final class DelayedTailHandler extends ChannelOutboundHandlerAdapter {
+
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private ChannelHandlerContext context;
+        private HttpContent message;
+        private ChannelPromise promise;
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise writePromise) throws Exception {
+            if (msg instanceof HttpContent && !(msg instanceof LastHttpContent)
+                    && ((HttpContent) msg).content().readableBytes() < CHUNK_SIZE) {
+                context = ctx;
+                message = (HttpContent) msg;
+                promise = writePromise;
+                writePromise.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        failure.compareAndSet(null, future.cause());
+                    }
+                });
+                return;
+            }
+            ctx.write(msg, writePromise);
+        }
+
+        private void release() {
+            if (message == null) {
+                return;
+            }
+            HttpContent delayedMessage = message;
+            ChannelPromise delayedPromise = promise;
+            ChannelHandlerContext delayedContext = context;
+            message = null;
+            promise = null;
+            context = null;
+            delayedContext.writeAndFlush(delayedMessage, delayedPromise);
+        }
+    }
+
+    private static final class OutboundSequenceRecorder extends ChannelOutboundHandlerAdapter {
+
+        private final List<String> messages = new ArrayList<>();
+        private final List<Integer> bodySizes = new ArrayList<>();
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof io.netty.handler.codec.http.HttpResponse) {
+                messages.add("HttpResponse");
+            }
+            if (msg instanceof LastHttpContent) {
+                messages.add("LastHttpContent");
+            } else if (msg instanceof HttpContent) {
+                messages.add("HttpContent");
+                bodySizes.add(((HttpContent) msg).content().readableBytes());
+            }
+            ctx.write(msg, promise);
+        }
+    }
+}

--- a/embedded-server/src/test/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponseTerminationTest.java
+++ b/embedded-server/src/test/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponseTerminationTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.plugins.server.netty;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.LastHttpContent;
+
+class NettyHttpResponseTerminationTest {
+
+    @Test
+    void reusesErrorResponseWhenFinishRunsAfterSendError() throws Exception {
+        TestChannel testChannel = new TestChannel();
+        try {
+            NettyHttpResponse response = testChannel.newResponse(null);
+
+            response.sendError(500, "failure");
+            response.finish();
+            testChannel.channel.runPendingTasks();
+
+            Assertions.assertEquals(List.of("FullHttpResponse:500"), testChannel.recorder.messages);
+        } finally {
+            testChannel.close();
+        }
+    }
+
+    @Test
+    void rejectsSendErrorAfterEmptyResponseTermination() throws Exception {
+        TestChannel testChannel = new TestChannel();
+        try {
+            NettyHttpResponse response = testChannel.newResponse(null);
+
+            response.finish();
+
+            Assertions.assertThrows(IllegalStateException.class, () -> response.sendError(500, "failure"));
+            Assertions.assertEquals(List.of("FullHttpResponse:200"), testChannel.recorder.messages);
+        } finally {
+            testChannel.close();
+        }
+    }
+
+    @Test
+    void rejectsSendErrorAfterHeadResponseTermination() throws Exception {
+        TestChannel testChannel = new TestChannel();
+        try {
+            NettyHttpResponse response = testChannel.newResponse(HttpMethod.HEAD);
+
+            response.finish();
+
+            Assertions.assertThrows(IllegalStateException.class, () -> response.sendError(500, "failure"));
+            Assertions.assertEquals(List.of("FullHttpResponse:200"), testChannel.recorder.messages);
+        } finally {
+            testChannel.close();
+        }
+    }
+
+    @Test
+    void repeatedFinishWritesOneTerminalResponse() throws Exception {
+        TestChannel testChannel = new TestChannel();
+        try {
+            NettyHttpResponse response = testChannel.newResponse(null);
+
+            response.finish();
+            response.finish();
+            testChannel.channel.runPendingTasks();
+
+            Assertions.assertEquals(List.of("FullHttpResponse:200"), testChannel.recorder.messages);
+        } finally {
+            testChannel.close();
+        }
+    }
+
+    @Test
+    void serializesEmptyTerminationAndSendError() throws Exception {
+        TestChannel testChannel = new TestChannel();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            BlockingEmptyResponse response = new BlockingEmptyResponse(
+                    testChannel.capture.context, ResteasyProviderFactory.getInstance());
+
+            CompletableFuture<Void> finish = CompletableFuture.runAsync(() -> finish(response), executor);
+            Assertions.assertTrue(response.awaitTerminalSelection(), "Timed out waiting for empty response selection");
+
+            CompletableFuture<Throwable> sendError = CompletableFuture.supplyAsync(() -> {
+                try {
+                    response.sendError(500, "failure");
+                    return null;
+                } catch (Throwable failure) {
+                    return failure;
+                }
+            }, executor);
+            Assertions.assertTrue(response.awaitSendErrorAttempt(), "Timed out starting sendError");
+            Assertions.assertFalse(sendError.isDone(), "sendError must wait for the terminal response transition");
+
+            response.allowTerminalSelection();
+            finish.get(5, TimeUnit.SECONDS);
+            Assertions.assertInstanceOf(IllegalStateException.class, sendError.get(5, TimeUnit.SECONDS));
+            Assertions.assertEquals(List.of("FullHttpResponse:200"), testChannel.recorder.messages);
+        } finally {
+            executor.shutdownNow();
+            testChannel.close();
+        }
+    }
+
+    private static void finish(NettyHttpResponse response) {
+        try {
+            response.finish();
+        } catch (IOException e) {
+            throw new CompletionException(e);
+        }
+    }
+
+    private static final class BlockingEmptyResponse extends NettyHttpResponse {
+
+        private final CountDownLatch terminalSelectionStarted = new CountDownLatch(1);
+        private final CountDownLatch terminalSelectionAllowed = new CountDownLatch(1);
+        private final CountDownLatch sendErrorAttempted = new CountDownLatch(1);
+
+        private BlockingEmptyResponse(ChannelHandlerContext ctx, ResteasyProviderFactory providerFactory) {
+            super(ctx, true, providerFactory);
+        }
+
+        @Override
+        public DefaultHttpResponse getEmptyHttpResponse() {
+            terminalSelectionStarted.countDown();
+            try {
+                if (!terminalSelectionAllowed.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to continue empty response selection");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to continue empty response selection", e);
+            }
+            return super.getEmptyHttpResponse();
+        }
+
+        @Override
+        public void sendError(int status, String message) throws IOException {
+            sendErrorAttempted.countDown();
+            super.sendError(status, message);
+        }
+
+        private boolean awaitTerminalSelection() throws InterruptedException {
+            return terminalSelectionStarted.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitSendErrorAttempt() throws InterruptedException {
+            return sendErrorAttempted.await(5, TimeUnit.SECONDS);
+        }
+
+        private void allowTerminalSelection() {
+            terminalSelectionAllowed.countDown();
+        }
+    }
+
+    private static final class TestChannel {
+
+        private final OutboundRecorder recorder = new OutboundRecorder();
+        private final ContextCapture capture = new ContextCapture();
+        private final EmbeddedChannel channel = new EmbeddedChannel(recorder, capture);
+
+        private NettyHttpResponse newResponse(HttpMethod method) {
+            return new NettyHttpResponse(capture.context, true, ResteasyProviderFactory.getInstance(), method);
+        }
+
+        private void close() {
+            channel.runPendingTasks();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static final class ContextCapture extends ChannelInboundHandlerAdapter {
+
+        private ChannelHandlerContext context;
+
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) {
+            context = ctx;
+        }
+    }
+
+    private static final class OutboundRecorder extends ChannelOutboundHandlerAdapter {
+
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof DefaultFullHttpResponse) {
+                messages.add("FullHttpResponse:"
+                        + ((DefaultFullHttpResponse) msg).status().code());
+            } else if (msg instanceof LastHttpContent) {
+                messages.add("LastHttpContent");
+            } else if (msg instanceof io.netty.handler.codec.http.HttpResponse) {
+                messages.add("HttpResponse");
+            }
+            ctx.write(msg, promise);
+        }
+    }
+}

--- a/embedded-server/src/test/java/org/jboss/resteasy/test/JacksonResponseLifecycleTest.java
+++ b/embedded-server/src/test/java/org/jboss/resteasy/test/JacksonResponseLifecycleTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor;
+import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+
+class JacksonResponseLifecycleTest {
+
+    private static final String VALUE = "x".repeat(5_000);
+    private static final String COMPLETE_JSON = "{\"value\":\"" + VALUE + "\"}";
+
+    private final OutboundSequenceRecorder recorder = new OutboundSequenceRecorder();
+    private NettyJaxrsServer server;
+    private HttpClient client;
+
+    private void startServer(ChannelHandler bodyWriteHandler) {
+        ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+        deployment.setProviders(List.of(new GZIPEncodingInterceptor()));
+
+        server = new NettyJaxrsServer();
+        server.setDeployment(deployment);
+        server.setHostname("127.0.0.1");
+        server.setPort(0);
+        server.setIoWorkerCount(1);
+        server.setExecutorThreadCount(1);
+        server.setHttpChannelHandlers(List.of(recorder, bodyWriteHandler));
+        server.start();
+        deployment.getRegistry().addPerRequestResource(JsonResource.class);
+
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void waitsForDelayedJacksonContentBeforeTerminatingResponse() throws Exception {
+        DelayedContentHandler delayedContent = new DelayedContentHandler();
+        startServer(delayedContent);
+
+        HttpResponse<byte[]> response = client.send(request(), HttpResponse.BodyHandlers.ofByteArray());
+        Assertions.assertTrue(delayedContent.awaitWrite(),
+                () -> "Timed out waiting for delayed write; outbound sequence: " + recorder.messages);
+        Assertions.assertNull(delayedContent.failure.get(),
+                () -> "A Jackson body write ran after response termination; outbound sequence: " + recorder.messages);
+        Assertions.assertEquals(COMPLETE_JSON, gunzip(response.body()));
+        Assertions.assertEquals("HttpResponse", recorder.messages.get(0));
+        Assertions.assertTrue(recorder.messages.contains("HttpContent"));
+        Assertions.assertEquals("LastHttpContent", recorder.messages.get(recorder.messages.size() - 1));
+    }
+
+    @Test
+    void closesConnectionWithoutTerminalContentWhenJacksonWriteFails() throws Exception {
+        FailedContentHandler failedContent = new FailedContentHandler();
+        startServer(failedContent);
+
+        Assertions.assertThrows(IOException.class,
+                () -> client.send(request(), HttpResponse.BodyHandlers.ofByteArray()));
+        Assertions.assertTrue(failedContent.awaitWrite(), "Timed out waiting for failed body write");
+        Assertions.assertSame(failedContent.expectedFailure, failedContent.failure.get());
+        Assertions.assertEquals("HttpResponse", recorder.messages.get(0));
+        Assertions.assertFalse(recorder.messages.contains("LastHttpContent"),
+                () -> "A failed response was terminated successfully: " + recorder.messages);
+    }
+
+    private HttpRequest request() {
+        return HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + server.getPort() + "/response-lifecycle"))
+                .timeout(Duration.ofSeconds(5))
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.ACCEPT_ENCODING, "gzip")
+                .GET()
+                .build();
+    }
+
+    private static String gunzip(byte[] body) throws IOException {
+        try (GZIPInputStream input = new GZIPInputStream(new ByteArrayInputStream(body));
+                ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            input.transferTo(output);
+            return output.toString(java.nio.charset.StandardCharsets.UTF_8);
+        }
+    }
+
+    @Path("response-lifecycle")
+    public static class JsonResource {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response get() {
+            return Response.ok(new JsonEntity(VALUE))
+                    .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+                    .build();
+        }
+    }
+
+    public static class JsonEntity {
+
+        private final String value;
+
+        JsonEntity(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private abstract static class ContentWriteHandler extends ChannelOutboundHandlerAdapter {
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch completed = new CountDownLatch(1);
+
+        final boolean awaitWrite() throws InterruptedException {
+            return completed.await(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @ChannelHandler.Sharable
+    private static final class DelayedContentHandler extends ContentWriteHandler {
+
+        private static final long WRITE_DELAY_MILLIS = 100;
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof HttpContent && !(msg instanceof LastHttpContent)) {
+                // Preserve the original promise and its pending state while moving actual pipeline forwarding past
+                // RESTEasy dispatch. The GZIP blocking bridge returns without waiting for this legitimate promise.
+                promise.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        failure.compareAndSet(null, future.cause());
+                    }
+                    completed.countDown();
+                });
+                ctx.executor().schedule(
+                        () -> ctx.writeAndFlush(msg, promise),
+                        WRITE_DELAY_MILLIS,
+                        TimeUnit.MILLISECONDS);
+                return;
+            }
+            ctx.write(msg, promise);
+        }
+    }
+
+    @ChannelHandler.Sharable
+    private static final class FailedContentHandler extends ContentWriteHandler {
+
+        private final IOException expectedFailure = new IOException("synthetic response body write failure");
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof HttpContent && !(msg instanceof LastHttpContent)) {
+                failure.set(expectedFailure);
+                ReferenceCountUtil.release(msg);
+                promise.setFailure(expectedFailure);
+                completed.countDown();
+                return;
+            }
+            ctx.write(msg, promise);
+        }
+    }
+
+    @ChannelHandler.Sharable
+    private static final class OutboundSequenceRecorder extends ChannelOutboundHandlerAdapter {
+
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof io.netty.handler.codec.http.HttpResponse) {
+                messages.add("HttpResponse");
+            }
+            if (msg instanceof LastHttpContent) {
+                messages.add("LastHttpContent");
+            } else if (msg instanceof HttpContent) {
+                messages.add("HttpContent");
+            }
+            ctx.write(msg, promise);
+        }
+    }
+}


### PR DESCRIPTION
## Why

We encountered this through clients occasionally receiving 200 OK responses whose JSON ended prematurely. The captured bodies repeatedly stopped at exact multiples of 1,000 bytes, matching `ChunkOutputStream`’s chunk size. Corresponding server errors showed `DefaultHttpContent` reaching Netty’s encoder in `state: 0`, after response termination. A deterministic reproducer then confirmed that `LastHttpContent` could overtake a pending body write.

```
2026-08-17T14:54:21.041Z ERROR [rest-api]
logger=me.magnet.ResponseWriteFailureHandler
event_name=netty_response_write_failed
failure_stage=async_write
failed_write_is_last=false
cause_type=io.netty.handler.codec.EncoderException

io.netty.handler.codec.EncoderException:
java.lang.IllegalStateException:
unexpected message type: DefaultHttpContent, state: 0
    at io.netty.handler.codec.http.HttpObjectEncoder.write(...)
    at me.magnet.ResponseWriteFailureHandler.write(...)
    at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(...)
Caused by: java.lang.IllegalStateException:
unexpected message type: DefaultHttpContent, state: 0
    at io.netty.handler.codec.http.HttpObjectEncoder.encodeNotHttpMessageContentTypes(...)
    at io.netty.handler.codec.http.HttpObjectEncoder.encode(...)
```

## Summary

RESTEasy’s Netty adapter can currently emit `LastHttpContent` while an earlier response-body write is still pending in the Netty pipeline.

When that happens, the client receives a valid HTTP response boundary after only part of the body. A late body chunk is rejected by Netty with:

```text
EncoderException:
IllegalStateException:
unexpected message type: DefaultHttpContent, state: 0
```

For JSON responses, this results in an apparently successful `200 OK` containing JSON truncated at the adapter’s 1,000-byte chunk boundary.

This PR makes response completion follow the actual asynchronous writes:

- every body write is tracked through its Netty promise;
- `LastHttpContent` is written only after all body writes succeed;
- body or terminal-write failure closes the connection instead of cleanly terminating a partial response;
- response termination is exactly once;
- `sendError()` is treated as a terminal full response and its future is reused by any subsequent `finish()`;
- HEAD, empty, keep-alive and non-keep-alive responses use the same completion model.

The change does not block the Netty event loop, introduce another body copy or add an unbounded collection. It adds constant state per response and one completion listener with a short synchronized callback per emitted body chunk. It does not introduce backpressure.

The regression tests reproduce the production failure with plain Jackson JSON:

```text
Before:
HttpResponse → 1,000-byte HttpContent → LastHttpContent → remaining HttpContent
                                                       ↳ EncoderException, state: 0

After:
HttpResponse → 1,000-byte HttpContent → remaining HttpContent → LastHttpContent
```

Thanks for maintaining this integration. We encountered this in production and put together a deterministic reproducer and a proposed fix. I’d particularly appreciate your view on coordinating completion in `ChunkOutputStream`, and whether you’d prefer the related `sendError()` changes in a separate PR.

<details>
<summary><strong>Detailed failure analysis and implementation notes</strong></summary>

## What happens

`ChunkOutputStream` splits response bodies into chunks of 1,000 bytes and sends each chunk using `ctx.writeAndFlush(...)`.

The old response lifecycle effectively was:

```text
Jackson writes JSON to ChunkOutputStream
    |
    +-- DefaultHttpContent: bytes 0–999
    +-- DefaultHttpContent: bytes 1000–1999
    +-- DefaultHttpContent: remaining bytes
    |
Jackson returns
    |
NettyHttpResponse.finish()
    |
    +-- flush OutputStream
    +-- write LastHttpContent
```

The individual Netty writes can still be pending when `finish()` runs. If one of them is delayed, the actual outbound sequence becomes:

```text
HttpResponse
DefaultHttpContent: bytes 0–999
LastHttpContent
DefaultHttpContent: remaining bytes
```

`LastHttpContent` is not merely another message. For a chunked HTTP/1.1 response it produces the final zero-sized chunk. According to [RFC 9112 section 7.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1), receiving that chunk completes the chunked transfer.

Hence the client is entitled to treat the response as finished after the first 1,000 bytes. It has no transport-level reason to reject the response. It only discovers the problem when the JSON parser encounters the incomplete document.

The late body chunk then reaches Netty’s encoder after termination. Netty correctly rejects it with:

```text
io.netty.handler.codec.EncoderException:
java.lang.IllegalStateException:
unexpected message type: DefaultHttpContent, state: 0
```

In Netty, [`state: 0` is `ST_INIT`](https://github.com/netty/netty/blob/netty-4.1.137.Final/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java#L70-L76). Encoding `LastHttpContent` [returns the encoder to that initial state](https://github.com/netty/netty/blob/netty-4.1.137.Final/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java#L432-L446). A subsequent `DefaultHttpContent` is therefore rejected as an unexpected message type.

This matches the production evidence:

- captured JSON prefixes end at exact multiples of 1,000 bytes;
- most prefixes end inside a JSON string or field name;
- other prefixes end between object or array entries;
- the server-side failure is a non-terminal `DefaultHttpContent` reaching the encoder in `state: 0`;
- the problem occurs without requiring GZIP compression.

## Why the individual components still conform to their contracts

This failure is a bit counter-intuitive because none of the individual components has to behave incorrectly for it to happen.

A Jakarta REST [`MessageBodyWriter`](https://jakarta.ee/specifications/restful-ws/3.1/apidocs/jakarta.ws.rs/jakarta/ws/rs/ext/messagebodywriter) writes the entity to the provided `OutputStream`. It must not close that stream, because the container owns the response lifecycle. Jackson therefore returns once it has written its serialized representation to the stream.

The Java [`OutputStream.flush()` contract](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/OutputStream.html#flush()) requires buffered bytes to be passed to the underlying destination. It does not guarantee that the final recipient has received them. Even for an operating-system-backed stream, flushing only guarantees that the bytes have been handed to the operating system.

Netty makes that distinction explicit: [all Netty I/O operations are asynchronous](https://netty.io/4.1/api/io/netty/channel/ChannelFuture.html). A write call can return immediately while the operation is still pending. The returned `ChannelFuture` reports completion or failure.

Finally, the HTTP encoder is correct to reject content after `LastHttpContent`. Accepting that content would violate the HTTP response boundary and could mix bytes with a subsequent keep-alive response.

Simply stated:

- Jackson correctly finishes writing to the provided stream.
- The stream correctly hands the bytes to Netty.
- Netty correctly reports completion asynchronously.
- The HTTP encoder correctly treats `LastHttpContent` as final.
- The client correctly treats the zero-sized chunk as successful response completion.

The missing piece is in the bridge between these contracts. The adapter treats “all writes have been submitted” as though it means “all writes have completed”. It then emits the terminal marker without observing the futures which Netty provides for exactly this purpose.

## What this changes

`ChunkOutputStream` now owns a response-wide write lifecycle.

For every emitted body chunk it:

1. increments a pending-write counter before calling Netty;
2. attaches a completion listener to that chunk’s promise;
3. records the first write failure;
4. decrements the counter when the promise completes.

`finish()` now:

1. flushes the current response output stream, including any wrapping interceptor stream;
2. marks the entity-output lifecycle as finished;
3. creates a response-wide promise;
4. writes response termination only when every registered body write has completed.

The resulting invariant is:

> `LastHttpContent` is emitted exactly once, and only after every body write registered before response completion has succeeded.

If a body write fails after the response has been committed, the adapter closes the channel and fails the response-wide promise. Once some body bytes may have reached the client, closing the transport is the only safe result. Writing `LastHttpContent` would turn an incomplete body into an apparently successful response.

The response retains the root `ChunkOutputStream` separately from any interceptor-provided wrapper. This lets `finish()` flush the outer stream while still coordinating the actual Netty body writes at the root.

Response termination is also stored as a single future. Repeated completion attempts, full error responses, HEAD responses and normal response completion therefore share the same terminal operation rather than emitting competing terminal messages.

## Why `sendError()` is part of the lifecycle change

`sendError()` writes a `DefaultFullHttpResponse`. A full response contains its complete entity and response boundary in one message. It is therefore already terminal; `finish()` must not append another empty response or `LastHttpContent`.

The old implementation did not model that:

```text
sendError()
    |
    +-- writeAndFlush(DefaultFullHttpResponse)
    +-- response remains uncommitted
    +-- write future is discarded

finish()
    |
    +-- response appears uncommitted
    +-- write another empty FullHttpResponse
```

That is a separate pre-existing failure path, but it becomes part of this change because normal responses and error responses now share one response-wide completion model. Leaving `sendError()` outside that model would mean `terminationFuture` does not represent every way in which a response can terminate.

`sendError()` now performs one atomic terminal-state transition:

1. check that the response has not already been committed;
2. build and transform the full error response;
3. mark the response committed;
4. write the full response;
5. store that write’s future as `terminationFuture`.

Both `sendError()` and `writeResponseTermination()` are synchronized. As such, they cannot both observe an unterminated response and emit competing terminal messages.

If `finish()` runs after `sendError()`, `ChunkOutputStream.finish()` still completes its local lifecycle. However, `writeResponseTermination()` returns the existing error-response future instead of writing anything else.

The resulting sequence is:

```text
sendError()
    |
    +-- committed = true
    +-- terminationFuture = write FullHttpResponse

finish()
    |
    +-- flush any remaining local stream state
    +-- reuse terminationFuture
    +-- do not write another response
```

This also preserves connection semantics. For non-keep-alive requests, the close listener follows the response-wide promise, which in turn follows the full error response’s write future. The connection therefore closes after that terminal write completes.

For keep-alive requests, a successfully written error response leaves the connection in a valid state for the next request. If the terminal write fails, the failure path closes the connection rather than leaving its response boundary uncertain.

## Empty and HEAD responses

Responses without a body still need a terminal write, but have no pending chunk promises to wait for.

`writeResponseTermination()` therefore keeps the existing distinction:

- if the response was committed through the chunk stream, write `LastHttpContent`;
- otherwise, write an empty `DefaultFullHttpResponse`.

HEAD responses do not have a `ChunkOutputStream`, hence they call `writeResponseTermination()` directly. They still benefit from the shared `terminationFuture`: repeated completion attempts return the same future and do not emit another response.

## Concurrency and ordering

Lifecycle state is guarded by the existing `writeLock`. This creates one ordering boundary for body submission, body completion and response termination.

There are a few relevant interleavings:

1. **All body writes complete before `finish()`**

   `finish()` observes zero pending writes and emits response termination immediately.

2. **`finish()` runs while body writes are pending**

   `finish()` records that termination was requested but does not write `LastHttpContent`. The listener completing the final body write emits termination.

3. **A body write fails while `finish()` is waiting**

   The failure is recorded and the channel is closed. Once the pending writes have settled, the response-wide promise completes exceptionally. No successful terminal content is written.

4. **A body write completes concurrently with `finish()`**

   Both paths inspect and update the counter while holding the same lock. Either `finish()` sees zero pending writes, or the final listener sees that finishing was requested. `responseWriteStarted` provides a final exactly-once guard around the terminal transition.

5. **`finish()` is called more than once**

   Later calls return the existing response-wide promise. They do not write another `LastHttpContent`.

6. **`sendError()` races with normal termination**

   `sendError()` and `writeResponseTermination()` synchronize on the response. Only one of them can create the terminal future. The other reuses it or observes that the response is already committed.

7. **A writer attempts to write after finishing**

   The write is rejected as committed. This is outside the normal Jakarta REST writer lifecycle: synchronous writers have returned, while asynchronous writers must only complete their returned stage after their writes have finished.

The terminal transition rechecks `finishRequested`, `pendingWrites` and `responseWriteStarted`. Some of these checks overlap with current call-site guarantees, but keeping them local makes `completeResponse()` enforce its own preconditions. A future call site cannot accidentally terminate the response while writes remain pending.

There is no blocking wait in any of these paths. In particular, the Netty event loop is not blocked while waiting for body promises. Completion continues through listeners.

## Failure handling

A successful response now requires two things:

1. every registered body promise succeeds;
2. the terminal write succeeds.

The response-wide promise completes only after both conditions hold.

If a body write fails:

- the first failure is preserved as the response failure;
- the channel is closed immediately;
- remaining pending writes are allowed to settle;
- no terminal response marker is emitted;
- the response-wide promise completes exceptionally.

The first failure is retained because later failures may merely be consequences of closing the channel. If Netty reports a failed future without a cause, the adapter creates an `IOException` rather than attempting to fail a promise with `null`.

If response termination itself fails, the adapter also closes the channel and fails the response-wide promise. A failed terminal write means the client cannot safely determine the response boundary, particularly on a keep-alive connection.

`trySuccess()` and `tryFailure()` are used when completing the response-wide promise. The state machine is intended to complete it once, but these calls prevent an unexpected duplicate callback from replacing the original transport result with a secondary promise-completion exception.

## Memory, allocation and garbage collection

This adds some bookkeeping, although it remains bounded.

Per response, `ChunkOutputStream` now retains:

- one pending-write counter;
- lifecycle booleans;
- the first write failure, if one occurs;
- one response-wide promise.

`NettyHttpResponse` retains:

- the root `ChunkOutputStream`;
- one terminal future once a terminal response has been written.

There is no collection of every promise or body chunk. Lifecycle memory is therefore constant per response rather than proportional to response size.

Each emitted `DefaultHttpContent` receives one additional completion listener. Because this is a bound method reference, it may result in one small short-lived allocation per emitted body chunk. The response-wide promise adds another short-lived allocation per response.

These objects remain reachable until their corresponding writes complete. Under normal circumstances they should die young and be handled by the young generation. Large responses already create one Netty promise and one copied `ByteBuf` per emitted chunk; this change adds lifecycle bookkeeping to that existing per-chunk work but does not add another body copy.

No new unbounded queue, buffer or retry mechanism is introduced.

If a downstream handler accepts a write but never completes its promise, the response will now remain pending instead of being terminated early. That can retain the response state and connection until the promise fails or the connection is closed. This is intentional fail-closed behaviour, but it means channel and request timeouts remain important. A handler which permanently loses a promise already violates Netty’s outbound contract.

## CPU, throughput and latency

The hot-path cost is constant per emitted body chunk:

- one counter increment;
- one listener registration;
- one listener callback;
- one counter decrement;
- a short synchronized section in the callback.

The response body is still submitted using the same number of 1,000-byte chunks. There is no additional encoding, compression, copying, retry, polling or scanning. Complexity remains `O(number of chunks)`.

The existing write methods already use `writeLock` to protect the shared chunk buffer. This change makes promise completion listeners use the same lock, so the writer thread and Netty event loop can briefly contend on response lifecycle state. The critical sections only update scalar fields and do not wait for network I/O.

`sendError()` also gains synchronization. This is not expected to be a hot path, and the lock covers one local state transition and one asynchronous write submission. It does not wait for that write to complete.

Normal response latency should remain effectively unchanged when body promises complete promptly. The terminal write follows as soon as the final body promise succeeds.

When the outbound pipeline is delayed, response completion is now delayed by the same amount. That is the intended behavioural change: previously the adapter reported a completed response while part of its body was still pending.

This change does not introduce backpressure. A writer can still enqueue body chunks faster than the transport sends them, and queued `ByteBuf` memory remains governed by Netty’s existing channel and writability behaviour. Adding bounded response backpressure would be a separate change.

Throughput could be affected for very large responses because the adapter currently emits relatively small 1,000-byte chunks, hence listener and synchronization overhead occurs frequently. No benchmark has been run, so I would not call this zero-cost. However, the change adds constant bookkeeping to operations for which Netty already creates promises and buffers. Changing the chunk size or introducing another streaming strategy would have broader compatibility and memory implications and is intentionally outside this fix.

Keep-alive correctness also matters for throughput. An invalid terminal marker can make a connection appear reusable while a previous response still has pending content. Waiting for the actual body lifecycle prevents those bytes from crossing the boundary into the next response.

## How this is reproduced

The tests cover the lifecycle at two levels.

The server-level Jackson test delays outbound content after RESTEasy dispatch has returned. Without the fix, `LastHttpContent` reaches the encoder before the delayed body. With the fix, the client receives the complete response.

A failure-path test rejects a body write and verifies that:

- the connection closes;
- the original body-write failure is preserved;
- no successful `LastHttpContent` is emitted.

Two additional pipeline-level tests reproduce the shapes observed in production without GZIP:

1. A plain Jackson document is split into a 1,000-byte prefix ending inside a JSON string and a delayed 512-byte tail.
2. A plain Jackson document is split into a 1,000-byte prefix ending exactly between object entries and a delayed 13-byte tail.

Against the old implementation, both produce:

```text
HttpResponse
HttpContent: 1,000 bytes
LastHttpContent
HttpContent: remaining bytes
```

The final write then fails with the same encoder exception:

```text
EncoderException:
IllegalStateException:
unexpected message type: DefaultHttpContent, state: 0
```

With this change, both produce:

```text
HttpResponse
HttpContent: 1,000 bytes
HttpContent: remaining bytes
LastHttpContent
```

The tests exercise both the repository’s Netty 4.1 line and Netty 4.2.16. The failure is therefore not specific to Netty 4.2; that version merely reports the invalid sequence clearly.

## Scope

This does not change the public API, response wire format, chunk size, Jackson configuration or compression behaviour.

It does change when a response is considered complete:

- normal responses complete after all body and terminal writes succeed;
- full error responses complete when their retained terminal write succeeds;
- failed body or terminal writes close the connection;
- repeated termination returns the existing future rather than writing another terminal message.

The change does not attempt to recover a response after a body write has failed. Once a partial response may have reached the client, recovery is unsafe.

Effectively, the adapter now treats every terminal response path consistently: complete body or full response first, terminal boundary once, and transport failure instead of clean truncation.

</details>